### PR TITLE
Benchmark suites

### DIFF
--- a/bench/basic_operations.exs
+++ b/bench/basic_operations.exs
@@ -1,0 +1,29 @@
+setup_crdt = fn number_of_items ->
+  {:ok, crdt1} = DeltaCrdt.start_link(DeltaCrdt.AWLWWMap)
+  {:ok, crdt2} = DeltaCrdt.start_link(DeltaCrdt.AWLWWMap)
+  {:ok, crdt3} = DeltaCrdt.start_link(DeltaCrdt.AWLWWMap)
+
+  DeltaCrdt.add_neighbours(crdt1, [crdt2, crdt3])
+  DeltaCrdt.add_neighbours(crdt2, [crdt1, crdt3])
+  DeltaCrdt.add_neighbours(crdt3, [crdt2, crdt1])
+
+  1..number_of_items |> Enum.each(fn x -> DeltaCrdt.mutate(crdt1, :add, [x, x]) end)
+
+  crdt1
+end
+
+crdt_100 = setup_crdt.(100)
+crdt_1000 = setup_crdt.(1000)
+crdt_10_000 = setup_crdt.(10_000)
+
+Benchee.run(%{
+  "read (with 100 items)" => fn -> DeltaCrdt.read(crdt_100) end,
+  "read (with 1.000 items)" => fn -> DeltaCrdt.read(crdt_1000) end,
+  "read (with 10.000 items)" => fn -> DeltaCrdt.read(crdt_10_000) end,
+  "add (with 100 items)" => fn -> DeltaCrdt.mutate(crdt_100, :add, ["key4", "value"]) end,
+  "add (with 1.000 items)" => fn -> DeltaCrdt.mutate(crdt_1000, :add, ["key4", "value"]) end,
+  "add (with 10.000 items)" => fn -> DeltaCrdt.mutate(crdt_10_000, :add, ["key4", "value"]) end,
+  "remove (with 100 items)" => fn -> DeltaCrdt.mutate(crdt_100, :remove, [10]) end,
+  "remove (with 1.000 items)" => fn -> DeltaCrdt.mutate(crdt_1000, :remove, [10]) end,
+  "remove (with 10.000 items)" => fn -> DeltaCrdt.mutate(crdt_10_000, :remove, [10]) end
+})

--- a/bench/propagation.exs
+++ b/bench/propagation.exs
@@ -1,0 +1,60 @@
+defmodule UpdateListener do
+  use GenServer
+
+  def wait_for_update(pid) do
+    GenServer.call(pid, :wait_for_update)
+  end
+
+  def init(args) do
+    {:ok, {nil, nil}}
+  end
+
+  def handle_call(:wait_for_update, from, {nil, nil}) do
+    {:noreply, {from, nil}}
+  end
+
+  def handle_call(:wait_for_update, from, {nil, response}) do
+    {:reply, :ok, {nil, nil}}
+  end
+
+  def handle_info({:crdt_update, _msg}, {nil, nil}) do
+    {:noreply, {nil, :updated}}
+  end
+
+  def handle_info({:crdt_update, _msg}, {from, nil}) do
+    GenServer.reply(from, :ok)
+    {:noreply, {nil, nil}}
+  end
+end
+
+defmodule Counter do
+  use Agent
+
+  def start_link(initial_value) do
+    Agent.start_link(fn -> initial_value end, name: __MODULE__)
+  end
+
+  def next do
+    Agent.update(__MODULE__, &(&1 + 1))
+    Agent.get(__MODULE__, & &1)
+  end
+end
+
+{:ok, listener} = GenServer.start_link(UpdateListener, [])
+
+{:ok, crdt1} = DeltaCrdt.start_link(DeltaCrdt.AWLWWMap)
+{:ok, crdt2} = DeltaCrdt.start_link(DeltaCrdt.AWLWWMap, notify: {listener, :crdt_update})
+
+DeltaCrdt.add_neighbours(crdt1, [crdt2])
+DeltaCrdt.add_neighbours(crdt2, [crdt1])
+
+Counter.start_link(0)
+
+Benchee.run(%{
+  "Add something" => fn ->
+    index = Counter.next()
+    IO.puts(index)
+    DeltaCrdt.mutate(crdt1, :add, [index, index])
+    UpdateListener.wait_for_update(listener) |> IO.inspect()
+  end
+})


### PR DESCRIPTION
This pull request adds benchmarking for the basic operations (read/add/remove).

- Benchmarks for `clear` were not possible due to timeouts
- Benchmarks for propagation are still in progress, and don't work yet. (The way of listening for updates currently only works the first time)