### PR TITLE
Use System.monotonic_time/1 instead of System.system_time/1

### DIFF
--- a/lib/delta_crdt/aw_lww_map.ex
+++ b/lib/delta_crdt/aw_lww_map.ex
@@ -101,7 +101,7 @@ defmodule DeltaCrdt.AWLWWMap do
 
     add =
       fn aw_set, context ->
-        aw_set_add(i, {value, System.system_time(:nanosecond)}, {aw_set, context})
+        aw_set_add(i, {value, System.monotonic_time(:nanosecond)}, {aw_set, context})
       end
       |> apply_op(key, state)
 


### PR DESCRIPTION
From the δ-CRDT paper: "Notice that is is up to the client
to ensure that supplied timestamps always grow monotonically.
Failure to do so is a common source of errors in timestamp
based systems"