### PR TITLE
Doc) Warn to use atom carefully

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ DeltaCrdt.read(crdt2)
 %{"CRDT" => "is magic!"}
 ```
 
+⚠️ **Use atom carefully** : Any key or value of atom type will be replicated across the nodes, which never be garbage collected.
+
 ## Telemetry metrics
 
 DeltaCrdt publishes the metric `[:delta_crdt, :sync, :done]`.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ DeltaCrdt.read(crdt2)
 %{"CRDT" => "is magic!"}
 ```
 
-⚠️ **Use atom carefully** : Any key or value of atom type will be replicated across the nodes, which never be garbage collected.
+⚠️ **Use atoms carefully** : Any atom contained in a key or value will be replicated across all nodes, and will never be garbage collected by the BEAM.
 
 ## Telemetry metrics
 


### PR DESCRIPTION
Add warning when an atom type is used.

See #35 for detail.