### PR TITLE
Fix for infinitely adding monitors for DOWNed neighbours

### DIFF
--- a/lib/delta_crdt/causal_crdt.ex
+++ b/lib/delta_crdt/causal_crdt.ex
@@ -258,7 +258,8 @@ defmodule DeltaCrdt.CausalCrdt do
 
   defp monitor_neighbours(state) do
     new_neighbour_monitors =
-      Enum.reduce(state.neighbours, state.neighbour_monitors, fn neighbour, monitors ->
+      Enum.filter(state.neighbours, &process_alive?/1)
+      |> Enum.reduce(state.neighbour_monitors, fn neighbour, monitors ->
         Map.put_new_lazy(monitors, neighbour, fn -> Process.monitor(neighbour) end)
       end)
 


### PR DESCRIPTION
This fixes an issue where `https://github.com/derekkraan/delta_crdt_ex/blob/master/lib/delta_crdt/causal_crdt.ex#L233` would constantly re-add a monitor for a node that is down each time the CRDT attempts to sync. This led to some strange behaviors where the CRDT ended up pretty much only handling `DOWN` messages and setting up new monitors.