### PR TITLE
add source_url

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -9,6 +9,7 @@ defmodule DeltaCrdt.MixProject do
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       package: package(),
+      source_url: "https://github.com/derekkraan/delta_crdt_ex",
       deps: deps()
     ]
   end


### PR DESCRIPTION
When you add a `source_url` to the project configuration in mix.exs,
ex_doc will automatically add a link to the proper file in the source
code for each function in the docs.

This adds the `source_url` so that ex_doc can do it's thing.