### PR TITLE
Update default `sync_interval` in docs

### DIFF
--- a/lib/delta_crdt.ex
+++ b/lib/delta_crdt.ex
@@ -44,7 +44,7 @@ defmodule DeltaCrdt do
   Start a DeltaCrdt and link it to the calling process.
 
   There are a number of options you can specify to tweak the behaviour of DeltaCrdt:
-  - `:sync_interval` - the delta CRDT will attempt to sync its local changes with its neighbours at this interval. Default is 50.
+  - `:sync_interval` - the delta CRDT will attempt to sync its local changes with its neighbours at this interval. Default is 200.
   - `:on_diffs` - function which will be invoked on every diff
   - `:max_sync_size` - maximum size of synchronization
   - `:storage_module` - module which implements `DeltaCrdt.Storage` behaviour


### PR DESCRIPTION
While looking in Hex docs, I thought that the sync_interval default value was 50, but a colleague pointed out that it's actually 200 in the code: https://github.com/derekkraan/delta_crdt_ex/blob/a7161f82ea0fb9d9893e0eb094459099d9849663/lib/delta_crdt.ex#L31