### PR TITLE
Clarify configuration for DeltaCRDT (sync_interval and max_sync_size)

### DIFF
--- a/lib/delta_crdt.ex
+++ b/lib/delta_crdt.ex
@@ -44,9 +44,9 @@ defmodule DeltaCrdt do
   Start a DeltaCrdt and link it to the calling process.
 
   There are a number of options you can specify to tweak the behaviour of DeltaCrdt:
-  - `:sync_interval` - the delta CRDT will attempt to sync its local changes with its neighbours at this interval. Default is 200.
+  - `:sync_interval` - the delta CRDT will attempt to sync its local changes with its neighbours at this interval (specified in milliseconds). Default is 200.
   - `:on_diffs` - function which will be invoked on every diff
-  - `:max_sync_size` - maximum size of synchronization
+  - `:max_sync_size` - maximum size of synchronization (specified in number of items to sync)
   - `:storage_module` - module which implements `DeltaCrdt.Storage` behaviour
   """
   @spec start_link(


### PR DESCRIPTION
Hello @derekkraan -- hope you don't mind me opening a PR without an associated issue.

I have been using Horde to manage GenServers in my applications and it works beautifully! In digging into the internals, I was curious which delta_crdt settings I could specify.

Despite the documentation here, I was unable to ascertain what units the `sync_interval` uses. Although I assumed it was milliseconds, looking through the code confirmed this since you're calling `Process.send_after/3` with the `sync_interval`.

This small change clarifies the function doc to include that this setting is in ms, which may be helpful for future users eager to tweak these settings. I also added a clarification to the `max_sync_size` setting, as (not knowing how a CRDT works), I was unsure if this was measured in items, bytes, or some other unit.

Feel free to merge if you agree or close if you disagree.
Either way, I appreciate your work on these libraries, and Happy New Year! 🍾 