### PR TITLE
Feature: allow reading only given keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,15 @@ DeltaCrdt.read(crdt1)
 
 # add a key/value in crdt1
 DeltaCrdt.mutate(crdt1, :add, ["CRDT", "is magic!"])
+DeltaCrdt.mutate(crdt1, :add, ["magic", "is awesome!"])
 
 # read it after it has been replicated to crdt2
 DeltaCrdt.read(crdt2)
-%{"CRDT" => "is magic!"}
+%{"CRDT" => "is magic!", "magic" => "is awesome!"}
+
+# read only a subset of keys
+DeltaCrdt.read(crdt2, ["magic"])
+%{"magic" => "is awesome!"}
 ```
 
 ⚠️ **Use atoms carefully** : Any atom contained in a key or value will be replicated across all nodes, and will never be garbage collected by the BEAM.

--- a/lib/delta_crdt.ex
+++ b/lib/delta_crdt.ex
@@ -30,6 +30,7 @@ defmodule DeltaCrdt do
 
   @default_sync_interval 200
   @default_max_sync_size 200
+  @default_timeout 5_000
 
   @type diff :: {:add, key :: any(), value :: any()} | {:remove, key :: any()}
   @type crdt_option ::
@@ -114,7 +115,7 @@ defmodule DeltaCrdt do
 
   For example, `DeltaCrdt.AWLWWMap` has a function `add` that takes 4 arguments. The last 2 arguments are supplied by DeltaCrdt internally, so you have to provide only the first two arguments: `key` and `val`. That would look like this: `DeltaCrdt.mutate(crdt, :add, ["CRDT", "is magic!"])`. This pattern is repeated for all mutation functions. Another example: to call `DeltaCrdt.AWLWWMap.clear`, use `DeltaCrdt.mutate(crdt, :clear, [])`.
   """
-  def mutate(crdt, f, a, timeout \\ 5000)
+  def mutate(crdt, f, a, timeout \\ @default_timeout)
       when is_atom(f) and is_list(a) do
     GenServer.call(crdt, {:operation, {f, a}}, timeout)
   end
@@ -132,7 +133,7 @@ defmodule DeltaCrdt do
   Read the state of the CRDT.
   """
   @spec read(crdt :: GenServer.server(), timeout :: timeout()) :: crdt_state :: term()
-  def read(crdt, timeout \\ 5000) do
+  def read(crdt, timeout \\ @default_timeout) do
     GenServer.call(crdt, :read, timeout)
   end
 end

--- a/lib/delta_crdt.ex
+++ b/lib/delta_crdt.ex
@@ -131,9 +131,24 @@ defmodule DeltaCrdt do
 
   @doc """
   Read the state of the CRDT.
+
+  Forwards arguments to the used crdt module, so `read(crdt, ["my-key"])` would call `crdt_module.read(state, ["my-key"])`.
+
+  For example, `DeltaCrdt.AWLWWMap` accepts a single key or a list of keys to limit the returned values instead of returning everything.
   """
+  @spec read(crdt :: GenServer.server()) :: crdt_state :: term()
   @spec read(crdt :: GenServer.server(), timeout :: timeout()) :: crdt_state :: term()
-  def read(crdt, timeout \\ @default_timeout) do
+  @spec read(crdt :: GenServer.server(), keys :: list()) :: crdt_state :: term()
+  @spec read(crdt :: GenServer.server(), keys :: list(), timeout :: timeout()) ::
+          crdt_state :: term()
+  def read(crdt), do: read(crdt, @default_timeout)
+  def read(crdt, keys) when is_list(keys), do: read(crdt, keys, @default_timeout)
+
+  def read(crdt, timeout) do
     GenServer.call(crdt, :read, timeout)
+  end
+
+  def read(crdt, keys, timeout) when is_list(keys) do
+    GenServer.call(crdt, {:read, keys}, timeout)
   end
 end

--- a/lib/delta_crdt.ex
+++ b/lib/delta_crdt.ex
@@ -134,7 +134,7 @@ defmodule DeltaCrdt do
 
   Forwards arguments to the used crdt module, so `read(crdt, ["my-key"])` would call `crdt_module.read(state, ["my-key"])`.
 
-  For example, `DeltaCrdt.AWLWWMap` accepts a single key or a list of keys to limit the returned values instead of returning everything.
+  For example, `DeltaCrdt.AWLWWMap` accepts a list of keys to limit the returned values instead of returning everything.
   """
   @spec read(crdt :: GenServer.server()) :: crdt_state :: term()
   @spec read(crdt :: GenServer.server(), timeout :: timeout()) :: crdt_state :: term()

--- a/lib/delta_crdt/aw_lww_map.ex
+++ b/lib/delta_crdt/aw_lww_map.ex
@@ -215,6 +215,8 @@ defmodule DeltaCrdt.AWLWWMap do
     end)
   end
 
+  def read(_crdt, []), do: %{}
+
   def read(%{value: values}, keys) when is_list(keys) do
     read(%{value: Map.take(values, keys)})
   end

--- a/lib/delta_crdt/causal_crdt.ex
+++ b/lib/delta_crdt/causal_crdt.ex
@@ -189,6 +189,10 @@ defmodule DeltaCrdt.CausalCrdt do
     {:reply, state.crdt_module.read(state.crdt_state), state}
   end
 
+  def handle_call({:read, args}, _from, state) do
+    {:reply, state.crdt_module.read(state.crdt_state, args), state}
+  end
+
   def handle_call({:operation, operation}, _from, state) do
     {:reply, :ok, handle_operation(operation, state)}
   end

--- a/test/aw_lww_map_test.exs
+++ b/test/aw_lww_map_test.exs
@@ -19,6 +19,15 @@ defmodule NewAWLWWMapTest do
              |> AWLWWMap.read()
   end
 
+  test "can add multiple values and only read one" do
+    new = AWLWWMap.new()
+    add1 = AWLWWMap.add(1, 2, :foo_node, new)
+    add2 = AWLWWMap.add(2, 3, :foo_node, add1)
+    state = AWLWWMap.join(add1, add2, [1, 2])
+
+    assert %{1 => 2} = AWLWWMap.read(state, 1)
+  end
+
   test "can remove elements" do
     add1 = AWLWWMap.add(1, 2, :foo_node, AWLWWMap.new())
     remove1 = AWLWWMap.remove(1, :foo_node, add1)

--- a/test/causal_crdt_test.exs
+++ b/test/causal_crdt_test.exs
@@ -176,7 +176,7 @@ defmodule CausalCrdtTest do
     DeltaCrdt.mutate(c, :add, ["key1", "value1"])
     DeltaCrdt.mutate(c, :add, ["key2", "value2"])
 
-    assert %{"key1" => "value1"} == DeltaCrdt.read(c, ["key1"])
+    assert %{"key1" => "value1"} == DeltaCrdt.read(c, ~w[key1])
   end
 
   test "can read multiple keys" do
@@ -186,6 +186,6 @@ defmodule CausalCrdtTest do
     DeltaCrdt.mutate(c, :add, ["key2", "value2"])
     DeltaCrdt.mutate(c, :add, ["key3", "value3"])
 
-    assert %{"key1" => "value1", "key3" => "value3"} == DeltaCrdt.read(c, [~w[key1 key3]])
+    assert %{"key1" => "value1", "key3" => "value3"} == DeltaCrdt.read(c, ~w[key1 key3])
   end
 end

--- a/test/causal_crdt_test.exs
+++ b/test/causal_crdt_test.exs
@@ -169,4 +169,23 @@ defmodule CausalCrdtTest do
     refute Map.has_key?(DeltaCrdt.read(c1), "key")
     refute Map.has_key?(DeltaCrdt.read(c2), "key")
   end
+
+  test "can read a single key" do
+    {:ok, c} = DeltaCrdt.start_link(AWLWWMap)
+
+    DeltaCrdt.mutate(c, :add, ["key1", "value1"])
+    DeltaCrdt.mutate(c, :add, ["key2", "value2"])
+
+    assert %{"key1" => "value1"} == DeltaCrdt.read(c, ["key1"])
+  end
+
+  test "can read multiple keys" do
+    {:ok, c} = DeltaCrdt.start_link(AWLWWMap)
+
+    DeltaCrdt.mutate(c, :add, ["key1", "value1"])
+    DeltaCrdt.mutate(c, :add, ["key2", "value2"])
+    DeltaCrdt.mutate(c, :add, ["key3", "value3"])
+
+    assert %{"key1" => "value1", "key3" => "value3"} == DeltaCrdt.read(c, [~w[key1 key3]])
+  end
 end


### PR DESCRIPTION
Resolves #54

---

This PR implements the proposal from [this comment](https://github.com/derekkraan/delta_crdt_ex/issues/54#issuecomment-771465313) where calling:

```elixir
DeltaCrdt.read(crdt, ["my-key"])
# => %{"my-key" => ...}
```

leads to a call to the used crdt module like this:

```elixir
crdt_module.read(state, ["my-key"])
```

That is, the given keys are 1to1 forwarded to the crdt_module as a second argument.

This allows to make use of the `read/2` function on `AWLWWMap` which makes it possible to only fetch the given keys from the map instead of fetching everything all the time.

For the user's benefit a small example was added to the README.